### PR TITLE
Fix/fixing formatting

### DIFF
--- a/src/categories/categories.controller.js
+++ b/src/categories/categories.controller.js
@@ -137,10 +137,10 @@ const categoriesController = {
 	getCategories: async (request, response) => {
 		Category.find((err, result) => {
 			if (err)
-				response.json({success: false, message: err.message});
+				response.json({ success: false, message: err.message });
 			
 			if (result)
-				response.send(result);
+				response.json({ success: true, categories: result });
 		})
 	},
 
@@ -150,7 +150,7 @@ const categoriesController = {
 				response.json({success: false, message: err.message});
 			
 			if (res)
-				response.send(res);
+				response.json({ success: true, category: result });
 		});
 	},
 
@@ -162,7 +162,7 @@ const categoriesController = {
 				response.json({success: false, message: err.message});
 			
 			if (res)
-				response.send(res);
+				response.json({ success: true, categories: res });
 		});
 	},
 

--- a/src/challenges/challenges.controller.js
+++ b/src/challenges/challenges.controller.js
@@ -64,7 +64,7 @@ const challengesController = {
 				response.json({success: false, message: err.message});
 			
 			if (result)
-				response.send(result);
+				response.json({ success: true, challenges: result });
 		})
     },
    
@@ -74,7 +74,7 @@ const challengesController = {
 				response.json({success: false, message: err.message});
 			
 			if (res)
-				response.send(res);
+				response.json({ success: true, challenge: res });
 		});
 	}
 

--- a/src/chatrooms/chatrooms.controller.js
+++ b/src/chatrooms/chatrooms.controller.js
@@ -90,11 +90,11 @@ const chatroomsController = {
 
         Chatroom.findOneAndUpdate({ _id: request.params.chatroom_id }, { communities: communities }, (err, res) => {
             if (err) {
-                response.send({ success: false, message: err });
+                response.json({ success: false, message: err });
             }
 
             if (res) {
-                response.json({ success: true, message: `successfully updated chatroom (${request.body.community_id}) added for chatroom (${request.params.chatroom_id})` });
+                response.json({ success: true });
             }
         });
 
@@ -122,7 +122,7 @@ const chatroomsController = {
                 response.json({success: false, message: err.message});
 
             if (result)
-                response.send(result);
+                response.json({ success: true, chatrooms: result });
         })
     },
 
@@ -132,7 +132,7 @@ const chatroomsController = {
                 response.json({success: false, message: err.message});
 
             if (res)
-                response.send(res);
+                response.json({ success: true, chatroom: res });
         });
     },
 

--- a/src/communities/communities.controller.js
+++ b/src/communities/communities.controller.js
@@ -93,7 +93,7 @@ const CommunityController = {
 				response.json({success: false, message: err.message});
 			
 			if (res)
-				response.send(res);
+				response.json({ success: true, communities: result });
 		});
 	},
 

--- a/src/messages/messages.controller.js
+++ b/src/messages/messages.controller.js
@@ -64,6 +64,17 @@ const messagesController = {
 			if (result)
 				response.json({ success: true, messages: result })
 		})
+	},
+
+			   
+	getMessage: async (request, response) => {
+		Message.findById(request.params.message_id.limit(20), (err, res) => {
+			if (err)
+				response.json({success: false, message: err.message});
+			
+			if (res)
+				response.send({ success: true, message: res });
+		});
 	}
 
 };

--- a/src/messages/messages.controller.js
+++ b/src/messages/messages.controller.js
@@ -35,7 +35,7 @@ const messagesController = {
 			}
 
 			if (res) {
-				response.json({ success: true, message: `successfully deleted message (${res._id})` });
+				response.json({ success: true });
 			}
 			
 		});
@@ -43,39 +43,28 @@ const messagesController = {
 	updateMessage: async (request, response) => {
 		
 		Message.findByIdAndUpdate(request.params.message_id, request.body, (err, res) => {
-					if (err) {
-						response.json({success: false, message: err.message});
-					}
-		
-					if (res) {
-						response.json({ success: true, message: `successfully updated message (${res._id})` });
-					}
-				});
-		
-			},
+			if (err) {
+				response.json({success: false, message: err.message});
+			}
+
+			if (res) {
+				response.json({ success: true });
+			}
+		});
+	
+	},
 
 	searchMessage: async (request, response) => {
-				var parameters = request.query;
-		
-				Message.find(parameters,null, {sort: {dateSent: 1}},(err, result) => {
-					if (err)
-						response.json({success: false, message: err.message});
-					
-					if (result)
-						response.send(result);
-				})
-			},
+		var parameters = request.query;
 
-			   
-		getMessage: async (request, response) => {
-			Message.findById(request.params.message_id.limit(20), (err, res) => {
-					if (err)
-						response.json({success: false, message: err.message});
-					
-					if (res)
-						response.send(res);
-				});
-			}
+		Message.find(parameters, null, {sort: {dateSent: 1} }, (err, result) => {
+			if (err)
+				response.json({ success: false, message: err.message });
+			
+			if (result)
+				response.json({ success: true, messages: result })
+		})
+	}
 
 };
 

--- a/src/posts/posts.controller.js
+++ b/src/posts/posts.controller.js
@@ -90,10 +90,10 @@ const postsController = {
     
             Post.find(parameters,(err, result) => {
                 if (err)
-                    response.json({success: false, message: err.message});
+                    response.json({ success: false, message: err.message });
                 
                 if (result)
-                    response.send(result);
+                    response.json({ success: true, posts: result });
             })
         },
 
@@ -103,7 +103,7 @@ const postsController = {
                     response.json({success: false, message: err.message});
                 
                 if (res)
-                    response.send(res);
+                    response.send({ success: true, post: res });
             });
         },
 

--- a/src/users/users.controller.js
+++ b/src/users/users.controller.js
@@ -543,13 +543,14 @@ const UserController = {
 
 		if (!userEmail) {
 			response.json({ success: false, message: 'User not found' });
-			return (false)
+			return
 		}
 		if (objRequest.token == userEmailToken.token){ 
 			userEmail.setPassword(objRequest.password);				
 			User.findOneAndUpdate({email:objRequest.email}, userEmail, (err, res) => {
 				if (err) {
-					response.send({success: false, message: err });
+					response.send({success: false, message: err.message });
+					return
 				}
 	
 				if (res) {
@@ -567,7 +568,7 @@ const UserController = {
 			});
 		} else {
 			response.json({ success: false, message: 'Invalid token' });
-			return (false)
+			return
 		}	
 	},
 


### PR DESCRIPTION
Fixing the formatting of endpoints so that they all follow the structure:

` { success: boolean, data: response } `

where `data` is something like 'posts' or 'messages' and the `response` is the actual data to be sent to the client